### PR TITLE
Resultページに渡された集計結果を表示

### DIFF
--- a/src/components/InnerAnswerPage.tsx
+++ b/src/components/InnerAnswerPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthState } from "react-firebase-hooks/auth";
 import { submitAnswer } from "@/logics/server/submitAnswer";
@@ -22,6 +22,10 @@ const InnerAnswerPage: React.FC = () => {
   const quiz = useFetchQuiz(quizIndex);
   const [selectedOption, setSelectedOption] = useState<number | null>(null);
   useDisableScroll();
+
+  useEffect(() => {
+    setSelectedOption(null);
+  }, [quizIndex]);
 
   const handleSubmit = async () => {
     if (user == undefined || null) throw new Error("You are not logged in!");

--- a/src/components/InnerResultPage.tsx
+++ b/src/components/InnerResultPage.tsx
@@ -1,25 +1,21 @@
 import bgImage from "@/assets/images/bg-resultPage.jpg";
 import { useDisableScroll } from "@/hooks/useDisableScroll";
-import useScoresSearchParams from "@/hooks/useScoresSearchParams";
+import { useFetchTeamsData } from "@/hooks/useFetchTeamsData";
+// import useScoresSearchParams from "@/hooks/useScoresSearchParams";
 import TeamRanking from "./TeamRanking";
 
 const InnerResultPage: React.FC = () => {
-  const scores = useScoresSearchParams();
+  // const scores = useScoresSearchParams();
 
-  const teams = [
-    { name: "チーム1", correctRate: 30 },
-    { name: "チーム2", correctRate: 80 },
-    { name: "チーム3", correctRate: 70 },
-    { name: "チーム4", correctRate: 90 },
-    { name: "チーム5", correctRate: 45 },
-    { name: "チーム6", correctRate: 30 },
-    { name: "チーム7", correctRate: 45 },
-    { name: "チーム8", correctRate: 50 },
-    { name: "チーム9", correctRate: 36 },
-    { name: "チーム10", correctRate: 34 },
+  // ResultPageに渡される配列の例
+  const scores = [
+    { teamId: "ba4Scr1BvgngsiSoBX2O", matchRate: 0.75 },
+    { teamId: "cmMAaITIRsj7oQvNW38b", matchRate: 0.64 },
   ];
-  const sortedTeams = [...teams].sort((a, b) => b.correctRate - a.correctRate);
-  const maxCorrectRate = sortedTeams[0].correctRate;
+
+  const teams = useFetchTeamsData(scores);
+  const sortedTeams = [...teams].sort((a, b) => b.matchRate - a.matchRate);
+  const maxMatchRate = sortedTeams[0]?.matchRate;
   useDisableScroll();
 
   return (
@@ -30,7 +26,7 @@ const InnerResultPage: React.FC = () => {
       <div className="absolute top-0 left-0 w-full h-full bg-white bg-opacity-10"></div>
       <div className="z-10 flex flex-col items-center w-full max-w-2xl p-8">
         <h1 className="text-5xl font-bold text-orange-500">結果は...</h1>
-        <TeamRanking teams={sortedTeams} maxCorrectRate={maxCorrectRate} />
+        <TeamRanking teams={sortedTeams} maxMatchRate={maxMatchRate} />
       </div>
     </div>
   );

--- a/src/components/TeamRanking.tsx
+++ b/src/components/TeamRanking.tsx
@@ -2,32 +2,32 @@ import { getColorClass } from "@/utils/getColorClass";
 
 interface Team {
   name: string;
-  correctRate: number;
+  matchRate: number;
 }
 
 interface TeamRankingProps {
   teams: Team[];
-  maxCorrectRate: number;
+  maxMatchRate: number;
 }
 
-const TeamRanking: React.FC<TeamRankingProps> = ({ teams, maxCorrectRate }) => {
+const TeamRanking: React.FC<TeamRankingProps> = ({ teams, maxMatchRate }) => {
   return (
     <div className="flex flex-col gap-1 w-full border-l-8 border-black py-6">
       {teams.map((team, index) => (
         <div
           key={team.name}
           className="flex items-center mb-2"
-          style={{ width: `${team.correctRate}%` }}
+          style={{ width: `${team.matchRate}%` }}
         >
           <div
             className={`flex-1 py-2 px-4 font-bold text-white ${getColorClass(index)}`}
           >
             {team.name}
           </div>
-          {team.correctRate === maxCorrectRate && (
+          {team.matchRate === maxMatchRate && (
             <div
               className="absolute left-60 ml-2 text-yellow-300 font-mono font-bold text-2xl bg-transparent"
-              style={{ left: `${team.correctRate * 0.7}%` }}
+              style={{ left: `${team.matchRate * 0.7}%` }}
             >
               WIN
             </div>

--- a/src/hooks/useFetchTeamsData.tsx
+++ b/src/hooks/useFetchTeamsData.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { fetchTeamById } from "@/logics/fetchTeams";
+
+interface TeamScore {
+  teamId: string;
+  matchRate: number;
+}
+
+interface TeamData {
+  name: string;
+  matchRate: number;
+}
+
+export const useFetchTeamsData = (scores: TeamScore[]) => {
+  const [teams, setTeams] = useState<TeamData[]>([]);
+
+  useEffect(() => {
+    const fetchTeamsData = async () => {
+      const teamsData = await Promise.all(
+        scores.map(async (score) => {
+          const team = await fetchTeamById(score.teamId);
+          return { name: team.name, matchRate: (score.matchRate || 0) * 100 };
+        })
+      );
+      setTeams(teamsData);
+    };
+
+    fetchTeamsData();
+  }, [scores]);
+
+  return teams;
+};


### PR DESCRIPTION
**実装した機能🎉**
- Resultページに渡された集計結果を表示できるようにしました。
- Answerページで回答されて次の問題に遷移した時に、選択した回答をリセットされるようにしました。

<モックのデータを表示>
<img width="305" alt="スクリーンショット 2024-06-23 19 41 29" src="https://github.com/tomizawakenshin/hackathon_team4/assets/159276434/b0721623-37fc-4a2a-ba31-59773e56c423">

<次の画面で回答をリセット>
<video controls src="https://github.com/tomizawakenshin/hackathon_team4/assets/159276434/de73503e-87cd-41f2-a09e-0f3146bc1c8b">


