### PR TITLE
全チームがクイズの投稿を完了したかの監視を開始する関数を追加

### DIFF
--- a/src/logics/startWatchingQuizPostedTeams.ts
+++ b/src/logics/startWatchingQuizPostedTeams.ts
@@ -1,0 +1,22 @@
+import { collection, onSnapshot } from "firebase/firestore";
+import { db } from "./firebase";
+import { Team } from "./types/team";
+import { fetchTeams } from "./fetchTeams";
+
+export async function startWatchingQuizPostedTeams(callback: () => void) {
+  const quizPostedTeamsRef = collection(db, "quiz-posted-teams");
+  onSnapshot(quizPostedTeamsRef, async (quizPostedTeamsSnapshot) => {
+    const quizPostedTeamIds = quizPostedTeamsSnapshot.docs.map((doc) => doc.id);
+    const teams = await fetchTeams();
+    const areAllTeamsPostedQuiz = checkIfAllTeamsPostedQuiz(teams, quizPostedTeamIds);
+    if (areAllTeamsPostedQuiz) callback();
+  });
+}
+
+export function checkIfAllTeamsPostedQuiz(teams: Team[], quizPostedTeamIds: string[]) {
+  let areAllTeamsPostedQuiz = 1;
+  teams.forEach((team) => {
+    if (!quizPostedTeamIds.includes(team.id)) areAllTeamsPostedQuiz *= 0;
+  });
+  return areAllTeamsPostedQuiz == 1;
+}


### PR DESCRIPTION
startWatchingQuizPostedTeams()に渡したコールバックが全チームがクイズの投稿を完了したときに実行されます。 waitingページで呼び出します。