### PR TITLE
チームに入っていないユーザを数えないように変更🏆

### DIFF
--- a/src/logics/server/goToPage.ts
+++ b/src/logics/server/goToPage.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation"
 
+/** 指定されたパスにredirect関数で遷移します。server component内で使うようにしてください。 */
 export async function goToPage(path: string) {
   redirect(path);
 }

--- a/src/logics/server/turnOnQuizCompletedFlag.ts
+++ b/src/logics/server/turnOnQuizCompletedFlag.ts
@@ -3,6 +3,7 @@
 import { doc, setDoc } from "firebase/firestore";
 import { db } from "../firebase";
 
+/** ユーザがすべてのクイズに答え終わったことを送信します。firestore上の指定されたユーザのフラグがオンになります */
 export async function turnOnQuizCompletedFlag(userId: string) {
   const flagRef = doc(db, "quizCompletedUsers", userId);
   await setDoc(flagRef, {

--- a/src/logics/startWatchingQuizCompletedUsers.ts
+++ b/src/logics/startWatchingQuizCompletedUsers.ts
@@ -25,7 +25,7 @@ function checkIfAllUsersCompletedQuizzes(completedUsersSnapshot: QuerySnapshot, 
 
   let areAllUsersCompleted = 1;
   users.forEach((user) => {
-    if (!completedUserIds.includes(user.id)) areAllUsersCompleted *= 0;
+    if (!completedUserIds.includes(user.id) && user.teamId != undefined) areAllUsersCompleted *= 0;
   });
 
   return areAllUsersCompleted == 1


### PR DESCRIPTION
ゲーム開始時にfirestore上でteamIdが登録されていないユーザを削除する処理も考えられていましたが、すべてのユーザをイテレーションしていたのがコード内で一箇所のみだったので、そこでteamIdの登録されていないユーザは数えないように処理を変更しました。